### PR TITLE
Implement timed wars/word sprints

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+# Issue/Feature
+
+
+# Checklist
+
+- [ ] Every pathway has a user-facing message
+- [ ] Every command appears in `help`
+- [ ] README updated
+

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Mmmorty will refuse to assign roles which have any permissions applied or that a
 
 If you want to opt out of this feature, start the bot with the `-color=FALSE` command line flag.
 
+#### Timed Sprints
+
+Use `@<botname> start sprint at :XX for Y` to start a timed "sprint"/"word war". This feature is targetted more towards the WriMo community, for which timed writing sessions help motivate writing groups to be productive for a set amount of time, and then subsequently report their results. Various alerts will be sent and users can request to be pinged on these updates, so this kind of timer can certainly be used in other contexts merely by changing the output strings. How it works:
+
+1. Start a sprint. The `:XX` notation provides a timezone-agnostic time to start. `Y` is the number of minutes the sprint should last.
+2. Users can use the `join sprint` and `leave sprint` commands to add/remove themselves from the list of users that get pinged at each interval. The user that starts the sprint is added automatically.
+3. Users receive three updates: the one-minute-before warning, the start notification, and the end notification.
+
+Multiple simultaneous sprints can be run. Each one is given an ID number to help manage them. This feature is disabled by default, so you will need the `-war=TRUE` flag to enable it.
+
 ## Setting Up
 
 1. Set up a bot with discord. A good guide for this is [here](https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token)

--- a/cmd/mmmorty/main.go
+++ b/cmd/mmmorty/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/todd-beckman/mmmorty/colorplugin"
 	"github.com/todd-beckman/mmmorty/pickplugin"
 	"github.com/todd-beckman/mmmorty/quoteplugin"
+	"github.com/todd-beckman/mmmorty/warplugin"
 )
 
 var (
@@ -25,6 +26,7 @@ var (
 	enableColor                bool
 	enablePicking              bool
 	enableQuotes               bool
+	enableWars                 bool
 )
 
 const (
@@ -42,6 +44,7 @@ func init() {
 	flag.BoolVar(&enableColor, "color", true, "Whether to enable setting colors")
 	flag.BoolVar(&enablePicking, "pick", true, "Whether to enable picking things")
 	flag.BoolVar(&enableQuotes, "quote", true, "Whether to enable quoting people")
+	flag.BoolVar(&enableWars, "war", false, "Whether to enable timed word wars")
 	flag.Parse()
 
 	if discordToken == "" {
@@ -91,6 +94,9 @@ func main() {
 		}
 		if enableQuotes {
 			bot.RegisterPlugin(discord, quoteplugin.New())
+		}
+		if enableWars {
+			bot.RegisterPlugin(discord, warplugin.New())
 		}
 	} else {
 		log.Println("(discordEmail and discordPassword) or discordToken is required.")

--- a/helpplugin.go
+++ b/helpplugin.go
@@ -47,7 +47,7 @@ func (p *helpPlugin) Help(bot *Bot, service Service, message Message, detailed b
 	help := []string{}
 
 	if len(commands) > 0 {
-		help = append(help, CommandHelp(service, helpCommand, "[topic]", fmt.Sprintf("Returns this information."))[0])
+		help = append(help, CommandHelp(service, helpCommand, "topic", "Posts this information.")[0])
 	}
 
 	return help

--- a/pickplugin/pickplugin.go
+++ b/pickplugin/pickplugin.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	maxWordCount = 100
-	pickCommand  = "pick between"
+	pickCommand  = "choose"
 	pickTemplate = "Uh, I'll go with this one: %s"
 )
 
@@ -66,7 +66,7 @@ func (p *PickPlugin) handlePickCommand(bot *mmmorty.Bot, service mmmorty.Service
 	options := []string{}
 	currentOption := []string{}
 
-	for index, word := range parts[1:] { // first word is 'between' because 'pick between'
+	for index, word := range parts {
 		if index > maxWordCount {
 			reply := fmt.Sprintf("Uh, %s, that message is kind of long. Is there any way you can shorten it?", requester)
 			service.SendMessage(message.Channel(), reply)
@@ -89,7 +89,7 @@ func (p *PickPlugin) handlePickCommand(bot *mmmorty.Bot, service mmmorty.Service
 	options = append(options, strings.Join(currentOption, " "))
 
 	if len(options) < 2 {
-		reply := fmt.Sprintf("Uh, %s, I didn't get that. Maybe put `or` between option?", requester)
+		reply := fmt.Sprintf("Uh, %s, I didn't get that. Maybe put `or` between options?", requester)
 		service.SendMessage(message.Channel(), reply)
 		return
 	}

--- a/warplugin/warplugin.go
+++ b/warplugin/warplugin.go
@@ -1,0 +1,301 @@
+package quoteplugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/todd-beckman/mmmorty"
+)
+
+const (
+	startWarCommand = "start sprint"
+	endWarCommand   = "end sprint"
+	joinWarCommand  = "join sprint"
+	leaveWarCommand = "leave sprint"
+	maxWarCount     = 10
+)
+
+type War struct {
+	// public
+	Channel   string   `json: "channel"`  // which channel the sprint was started from
+	Duration  int      `json: "duration"` // minutes
+	Name      string   `json: "name"`
+	Sprinters []string `json: "sprinters"` // list of user ID's of players to ping for updates
+	Start     int64    `json: "start"`     // Unix time, the number of seconds elapsed since January 1, 1970 UTC.
+
+	// private
+	alertTimer *time.Timer
+	startTimer *time.Timer
+	endTimer   *time.Timer
+}
+
+type WarPlugin struct {
+	bot  *mmmorty.Bot
+	Wars map[string]*War `json: "wars"` // map of name to war
+}
+
+func timeWithoutSeconds() time.Time {
+	now := time.Now()
+	return time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), 0, 0, now.Location)
+}
+
+func stringifySprinters(war *War) string {
+	notifyUsers := []string{}
+	for _, sprinter := range war.Sprinters {
+		notifyUsers = append(notifyUsers, fmt.Sprintf("<@%s>", sprinter))
+	}
+	return strings.Join(notifyUsers, " ")
+}
+
+func (p *WarPlugin) pickName() string {
+	var name string
+	for p.Wars[name] != nil {
+		name = fmt.Sprintf(
+			"%s%s%s",
+			rand.Intn(10),
+			rand.Intn(10),
+			rand.Intn(10),
+		)
+	}
+
+	return name
+}
+
+func (p *WarPlugin) alertNotify(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message, name string) {
+	war, ok := p.Wars[war]
+	if !ok {
+		return
+	}
+
+	notifyString := stringifySprinters(war)
+	reply := fmt.Sprintf("Sprint %s is starting in one minute! %s", name, notifyString)
+	service.SendMessage(war.Channel)
+}
+
+func (p *WarPlugin) startNotify(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message, name string) {
+	war, ok := p.Wars[war]
+	if !ok {
+		return
+	}
+
+	notifyString := stringifySprinters(war)
+	reply := fmt.Sprintf("Sprint %s starts now! %s", name, notifyString)
+	service.SendMessage(war.Channel)
+}
+
+func (p *WarPlugin) endNotify(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message, name string) {
+	war, ok := p.Wars[war]
+	if !ok {
+		return
+	}
+
+	notifyString := stringifySprinters(war)
+	reply := fmt.Sprintf("Sprint %s has ended! %s", name, notifyString)
+	service.SendMessage(war.Channel)
+
+	delete(p.Wars, name)
+}
+
+func (p *WarPlugin) Help(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message, detailed bool) []string {
+	help := mmmorty.CommandHelp(service, startWarCommand,
+		"at :XX for Y (mins)", "starts a sprint starting when the minute hand points to XX and lasting for Y minutes")
+	help = append(help, mmmorty.CommandHelp(service, endWarCommand, "<id>",
+		"Ends the sprint with the given name.")[0])
+	help = append(help, mmmorty.CommandHelp(service, joinWarCommand, "<id>",
+		"Adds you to the list of people to notify for the given sprint.")[0])
+	help = append(help, mmmorty.CommandHelp(service, leaveWarCommand, "<id>",
+		"Removes you from the list of people to notify for the given sprint.")[0])
+	return help
+}
+
+func (p *WarPlugin) Load(bot *mmmorty.Bot, service mmmorty.Service, data []byte) error {
+	if data != nil {
+		if err := json.Unmarshal(data, p); err != nil {
+			log.Println("Error loading data", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *WarPlugin) Message(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message) {
+	defer mmmorty.MessageRecover()
+
+	if service.Name() != mmmorty.DiscordServiceName {
+		return
+	}
+
+	if service.IsMe(message) {
+		return
+	}
+
+	if mmmorty.MatchesCommand(service, startWarCommand, message) {
+		p.handleStartWarCommand(bot, service, message)
+	}
+}
+
+func (p *WarPlugin) handleStartWarCommand(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message) {
+	requester := fmt.Sprintf("<@%s>", message.UserID())
+
+	if service.IsPrivate(message) {
+		reply := fmt.Sprintf("Uh, %s, I can't start sprints privately.", requester)
+		service.SendMessage(message.Channel(), reply)
+		return
+	}
+
+	if len(p.Quotes) >= maxQuoteCount {
+		reply := fmt.Sprintf("Uh, %s, I can't remember all these sprints. Could you end some first?", requester)
+		service.SendMessage(message.Channel(), reply)
+		return
+	}
+	_, parts := mmmorty.ParseCommand(service, message)
+
+	// "sprint at :XX for Y (mins)"
+	if len(parts) < 5 || parts[1] != "at" || parts[3] != "for" {
+		reply := fmt.Sprintf("Uh, %s, I don't quite know what you mean. Have you tried `%s at :XX for Y (mins)`?", requester, startWarCommand)
+		service.SendMessage(message.Channel(), reply)
+		return
+	}
+
+	// get the :XX minutes portion
+	requestedTime := parts[2]
+	if requestedTime[0] == ':' {
+		requestedTime = requestedTime[1:]
+	}
+	minutes, err := strconv.Atoi(requestedTime)
+	if err != nil {
+		reply := fmt.Sprintf("Uh, %s, that start time doesn't make sense. `:XX` should work fine.", requester)
+		service.SendMessage(message.Channel(), reply)
+		return
+	}
+	if minutes < 0 || minutes > 60 {
+		reply := fmt.Sprintf("Uh, %s, that start time doesn't make sense. Maybe try a number between 0 and 60, you know?", requester)
+		service.SendMessage(message.Channel(), reply)
+		return
+	}
+
+	// get the Y (mins) portion
+	requestedDuration := parts[4]
+	duration, err := strconv.Atoi(requestedDuration)
+	if err != nil {
+		reply := fmt.Sprintf("Uh, %s, that duration doesn't make sense. A number for the minutes should work fine.", requester)
+		service.SendMessage(message.Channel(), reply)
+		return
+	}
+	if duration > 180 {
+		reply := fmt.Sprintf("Gee, %s, I don't know if Rick will let me keep a sprint going for that long.", requester)
+		service.SendMessage(message.Channel(), reply)
+	}
+
+	now := timeWithoutSeconds()
+	nowMinutes := now.Minute()
+
+	// Cannot start the timer for the current minute
+	if minutes == nowMinutes {
+		// TODO: print error
+		return
+	}
+
+	// Rollover to the next hour
+	if minutes < nowMinutes {
+		minutes += 60
+	}
+
+	// unique ID used to remember this war
+	name := p.pickName()
+
+	// when to give the minute-before alert
+	minutesToAlert := minutes - nowMinutes - 1
+	var alertTimer *time.Timer
+	if minutesToAlert > 0 {
+		alertingIn := time.ParseDuration(fmt.Sprintf("%sm", minutesToAlert))
+		alertTimer = time.AfterFunc(alertingIn, func() {
+			p.alertNotify(bot, service, message, name)
+		})
+	}
+
+	// when to give the starting alert
+	minutesToStart := minutes - nowMinutes
+	startingIn := time.ParseDuration(fmt.Sprintf("%sm", minutesToStart))
+	startTimer := time.AfterFunc(startingIn, func() {
+		p.startNotify(bot, service, message, name)
+	})
+
+	// when to give the ending alert
+	minutesToEnd := minutesFromNow + duration
+	endingIn := time.ParseDuration(fmt.Sprintf("%sm", minutesToEnd))
+	endTimer := time.AfterFunc(endingIn, func() {
+		p.endNotify(bot, service, message, name)
+	})
+
+	// backup the war info
+	war := &War{
+		Channel:   message.Channel(),
+		Duration:  duration,
+		Name:      name,
+		Sprinters: []string{message.UserID()},
+		Start:     startingTime.Unix(),
+
+		alertTimer: alertTimer,
+		startTimer: startTimer,
+		endTimer:   endTimer,
+	}
+	p.Wars[name] = war
+
+	reply := fmt.Sprintf("Ok, %s, you got it! I added you to this sprint. Use `%s %s` to get updates, `%s %s` to stop getting them, and `%s %s` to cancel this sprint.")
+	service.SendMessage(message.Channel(), reply)
+}
+
+func (p *WarPlugin) handleEndWarCommand(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message) {
+	requester := fmt.Sprintf("<@%s>", message.UserID())
+
+	_, parts := mmmorty.ParseCommand(service, message)
+	if len(parts) < 2 {
+		reply := fmt.Sprintf("Uh, %s, what was the sprint you wanted to end?", requester)
+		service.SendMessage(message.Channel(), reply)
+		return
+	}
+
+	name := parts[1]
+
+	war, ok := p.Wars[name]
+	if !ok {
+		reply := fmt.Sprintf("Uh, %s, I don't see a war by that name.", requester)
+		service.SendMessage(message.Channel(), reply)
+		return
+	}
+
+	quoteCount := len(p.Quotes)
+	if quoteCount == 0 {
+		reply := fmt.Sprintf("Uh, %s, I don't know any quotes yet. Maybe you could add them?", requester)
+		service.SendMessage(message.Channel(), reply)
+		return
+	}
+
+	index := rand.Intn(quoteCount)
+	quote := p.Quotes[index]
+	reply := fmt.Sprintf(quoteTemplate, quote.Author, quote.Quote)
+	service.SendMessage(message.Channel(), reply)
+}
+
+func (p *WarPlugin) Save() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+func (p *WarPlugin) Stats(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message) []string {
+	return []string{}
+}
+
+func (p *WarPlugin) Name() string {
+	return "Quote"
+}
+
+func New() mmmorty.Plugin {
+	return &WarPlugin{}
+}


### PR DESCRIPTION
# Issue/Feature

Timed word wars. Users specify a start time and a duration and Mmmorty will notify them one minute before the start, on the start, and on the end. Other users can opt in and out of notifications for this war, and wars can be manually ended as desired.

They are written to file for now but the first iteration does not implement restoring a word war from file.

# Checklist

- [x] Every pathway has a user-facing message
- [x] Every command appears in `help`
- [x] README updated

