### PR TITLE
Wars should state duration when starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use `@<botname> help` to view the commands.
 
 #### Picking things
 
-`@<botname> pick between <option> or <option> (or ...)` - asks Morty to pick something for you.
+`@<botname> choose <option> or <option> (or ...)` - asks Morty to pick something for you.
 
 If you want to opt out of this feature, start the bot with the `-pick=FALSE` command line flag.
 

--- a/bot.go
+++ b/bot.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -31,9 +32,17 @@ type Bot struct {
 }
 
 // MessageRecover is the default panic handler
-func MessageRecover() {
+func (b *Bot) MessageRecover(service Service, channel string) {
 	if r := recover(); r != nil {
+		panic := fmt.Sprintf("%s", r)
+		// log first
+		log.Println(panic)
 		log.Println("Recovered:", string(debug.Stack()))
+
+		// notify owner
+		discord := service.(*Discord)
+		owner := fmt.Sprintf("<@%s>", discord.OwnerUserID)
+		service.SendMessage(channel, fmt.Sprintf("%s: Something went wrong. Summary: %s", owner, panic))
 	}
 }
 

--- a/colorplugin/colorplugin.go
+++ b/colorplugin/colorplugin.go
@@ -65,7 +65,7 @@ func (p *ColorPlugin) Load(bot *mmmorty.Bot, service mmmorty.Service, data []byt
 }
 
 func (p *ColorPlugin) Message(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message) {
-	defer mmmorty.MessageRecover()
+	defer bot.MessageRecover(service, message.Channel())
 
 	if service.Name() != mmmorty.DiscordServiceName {
 		return

--- a/commandplugin.go
+++ b/commandplugin.go
@@ -132,7 +132,7 @@ func (p *CommandPlugin) Help(bot *Bot, service Service, message Message, detaile
 // Message handler.
 // Iterates over the registered commands and executes them if the message matches.
 func (p *CommandPlugin) Message(bot *Bot, service Service, message Message) {
-	defer MessageRecover()
+	defer bot.MessageRecover(service, message.Channel())
 	if !service.IsMe(message) {
 		for commandString, command := range p.commands {
 			if MatchesCommand(service, commandString, message) {

--- a/pickplugin/pickplugin.go
+++ b/pickplugin/pickplugin.go
@@ -37,7 +37,7 @@ func (p *PickPlugin) Load(bot *mmmorty.Bot, service mmmorty.Service, data []byte
 }
 
 func (p *PickPlugin) Message(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message) {
-	defer mmmorty.MessageRecover()
+	defer bot.MessageRecover(service, message.Channel())
 
 	if service.Name() != mmmorty.DiscordServiceName {
 		return

--- a/quoteplugin/quoteplugin.go
+++ b/quoteplugin/quoteplugin.go
@@ -50,7 +50,7 @@ func (p *QuotePlugin) Load(bot *mmmorty.Bot, service mmmorty.Service, data []byt
 }
 
 func (p *QuotePlugin) Message(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message) {
-	defer mmmorty.MessageRecover()
+	defer bot.MessageRecover(service, message.Channel())
 
 	if service.Name() != mmmorty.DiscordServiceName {
 		return

--- a/warplugin/warplugin.go
+++ b/warplugin/warplugin.go
@@ -141,7 +141,7 @@ func (p *WarPlugin) Load(bot *mmmorty.Bot, service mmmorty.Service, data []byte)
 }
 
 func (p *WarPlugin) Message(bot *mmmorty.Bot, service mmmorty.Service, message mmmorty.Message) {
-	defer mmmorty.MessageRecover()
+	defer bot.MessageRecover(service, message.Channel())
 
 	if service.Name() != mmmorty.DiscordServiceName {
 		return

--- a/warplugin/warplugin.go
+++ b/warplugin/warplugin.go
@@ -76,7 +76,14 @@ func (p *WarPlugin) alertNotify(bot *mmmorty.Bot, service mmmorty.Service, messa
 	}
 
 	notifyString := stringifySprinters(war)
-	reply := fmt.Sprintf("Sprint %s is starting in one minute! %s", name, notifyString)
+
+	duration := war.Duration
+	minuteString := "minutes"
+	if duration == 1 {
+		minuteString = "minute"
+	}
+
+	reply := fmt.Sprintf("Sprint %s is starting in one minute, when it will go for %v %s! %s", name, duration, minuteString, notifyString)
 	service.SendMessage(war.Channel, reply)
 }
 
@@ -87,7 +94,13 @@ func (p *WarPlugin) startNotify(bot *mmmorty.Bot, service mmmorty.Service, messa
 	}
 
 	notifyString := stringifySprinters(war)
-	reply := fmt.Sprintf("Sprint %s starts now! %s", name, notifyString)
+
+	duration := war.Duration
+	minuteString := "minutes"
+	if duration == 1 {
+		minuteString = "minute"
+	}
+	reply := fmt.Sprintf("Sprint %s starts now and goes for %v %s! %s", name, notifyString, minuteString, notifyString)
 	service.SendMessage(war.Channel, reply)
 }
 


### PR DESCRIPTION
# Issue/Feature

Wars do not say how long the sprint will be on the one minute alert and the start message but they should.

Also make panicking slightly more helpful by pinging the owner when it happens. 

# Checklist

- [x] Every pathway has a user-facing message
- [ ] (N/A) Every command appears in `help`
- [ ] (N/A) README updated

