### PR TITLE
bug fix sprint too long

### DIFF
--- a/start-morty.sh
+++ b/start-morty.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+go/bin/mmmorty &

--- a/warplugin/warplugin.go
+++ b/warplugin/warplugin.go
@@ -206,6 +206,7 @@ func (p *WarPlugin) handleStartWarCommand(bot *mmmorty.Bot, service mmmorty.Serv
 	if duration > 180 {
 		reply := fmt.Sprintf("Gee, %s, I don't know if Rick will let me keep a sprint going for that long.", requester)
 		service.SendMessage(message.Channel(), reply)
+		return
 	}
 
 	now := timeWithoutSeconds()


### PR DESCRIPTION
# Issue/Feature

There is no return statement for the issue with sprints being set to go too long.

# Checklist

- [x] Every pathway has a user-facing message
- [x] Every command appears in `help`
- [ ] README updated

